### PR TITLE
Use loadeddata instead of loadedmetadata

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -46,7 +46,7 @@
 				source.type = 'video/mp4';
 				video.appendChild(source);
 
-				video.addEventListener('loadedmetadata', function () {
+				video.addEventListener('loadeddata', function () {
 					if (canvas.width !== this.videoWidth || canvas.height !== this.videoHeight) {
 						canvas.width = this.width = this.videoWidth;
 						canvas.height = this.height = this.videoHeight;


### PR DESCRIPTION
The video dimension  in metadata is not the real video dimension. It needs to wait for first frame is decoded to retrieve the correct video dimension.
The detail discuss is in https://bugzilla.mozilla.org/show_bug.cgi?id=1206948.
It have been tested in Firefox 47.01, Chrome and Edge.
